### PR TITLE
Distinguish multiple referentials that have the same name

### DIFF
--- a/src/lib/object/actions.cc
+++ b/src/lib/object/actions.cc
@@ -668,7 +668,7 @@ void ObjectActions::setAutomaticReferential( const set<AObject*> & obj )
             else if( uid.toString() != sref )
             {
                 // sref doesn't correspond to an UUID, so it is not unique
-              sref = sref + " for " + (*io)->name();
+              sref = sref + " " + toString(i) + " for " + (*io)->name();
               ref = 0;
               uid = carto::UUID();
             }


### PR DESCRIPTION
When an image has multiple transformations (e.g. qform and sform) that point to a similarly-named referential (e.g. `Coordinates aligned to another file or to anatomical truth`), Anatomist only shows the last one.

This patch inserts the index of the transformation in its name, to make it unique. I am not sure if there are better ways, feel free to edit.