### PR TITLE
Use the "referentials" and "transformations" of Graphs

### DIFF
--- a/src/lib/graph/Graph.cc
+++ b/src/lib/graph/Graph.cc
@@ -1887,18 +1887,6 @@ void AGraph::updateAfterAimsChange()
 void AGraph::setProperties( Object options )
 {
   AObject::setProperties( options );
-
-  Motion m = GraphManip::talairach( *d->graph );
-  if( !m.isIdentity() )
-  {
-    GenericObject *go = attributed();
-    vector<string> refs;
-    refs.push_back( StandardReferentials::acPcReferential() );
-    go->setProperty( "referentials", refs );
-    vector< vector<float> > mot;
-    mot.push_back( m.toVector() );
-    go->setProperty( "transformations", mot );
-  }
 }
 
 


### PR DESCRIPTION
**This PR depends on https://github.com/brainvisa/aims-free/pull/18 being merged first**

Recent aims is able to read the Talairach transformations into these header fields upon loading a Graph (see https://github.com/brainvisa/aims-free/commit/d2c18a78abcc22b2929e8456cef650d3369dd73d). Therefore, we can now avoid resetting these fields, and shadowing the other transformations that they may contain.