### PR TITLE
update because ptk name has changed to gkg

### DIFF
--- a/shared/plugins/anatomist.plugins
+++ b/shared/plugins/anatomist.plugins
@@ -11,6 +11,6 @@ attributes = {
     'libpyanatomistmodule.so',
     'libanavolrender.so',
     'libanavtk.so',
-    'libptk-anatomist-plugin.so'
+    'libgkg-anatomist-plugin.so'
   ],
 }


### PR DESCRIPTION
PTK does no longer exists. It was replaced by GKG. The plugin list was updated to load the gkg plugin.