### PR TITLE
Fixed compilation with Conda/Qwt 6.2.0

### DIFF
--- a/src/histogram/winhisto/histoWin.cc
+++ b/src/histogram/winhisto/histoWin.cc
@@ -277,7 +277,7 @@ void QAHistogramWindow::refreshNow()
       QwtPlotCurve	*crv = d->mcurve[ *it ];
       crv->setPen( QPen( QColor( d->pcol[ crv ] ) ) );
 #if QWT_VERSION >= 0x060000
-      QwtCPointerData *cp = new QwtCPointerData( x_curve, phisto[ *it ],
+      QwtCPointerData<double> *cp = new QwtCPointerData<double>( x_curve, phisto[ *it ],
                                                  qaHisto.getDim() );
       crv->setData( cp );
 #else

--- a/src/roibase/action/histoplot.cc
+++ b/src/roibase/action/histoplot.cc
@@ -42,6 +42,7 @@
 #include <anatomist/reference/Transformation.h>
 #include <graph/tree/tree.h>
 #include <qwt_plot.h>
+#include <qwt_spline_curve_fitter.h>
 #include <qspinbox.h>
 #include <qstring.h>
 #include <qfiledialog.h>
@@ -353,7 +354,7 @@ RoiHistoPlot::showImageHisto()
   imageHisto->setStyle( QwtPlotCurve::Spline );
 #endif
 #if QWT_VERSION >= 0x060000
-  imageHisto->setData( new QwtCPointerData( x, y, myNbOfBins ) );
+  imageHisto->setData( new QwtCPointerData<double>( x, y, myNbOfBins ) );
 #else
   imageHisto->setData( x, y, myNbOfBins ) ;
 #endif
@@ -473,7 +474,7 @@ RoiHistoPlot::showGraphHisto()
     
     regionHisto->setStyle( QwtPlotCurve::Lines ) ;
 #if QWT_VERSION >= 0x060000
-    regionHisto->setData( new QwtCPointerData( x, y, myNbOfBins ) );
+    regionHisto->setData( new QwtCPointerData<double>( x, y, myNbOfBins ) );
 #else
     regionHisto->setData( x, y, myNbOfBins );
 #endif


### PR DESCRIPTION
I had compilation error using Conda. I do not know why it did not fail before. It is possible that Qwt was not installed in my previous tests with Conda, maybe the roi module was not compiled (I did not check if there is a CMake rule for that). Current Qwt version in Conda is 6.2.0, there are also 6.1.* versions. I wonder if the Qwt6 code could compile without the missing `<double>` ? In any case, we'll have to test the ROI module with Conda.